### PR TITLE
switch angular to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,13 @@
   },
   "homepage": "https://github.com/bcherny/ngimport#readme",
   "devDependencies": {
+    "@types/angular": "^1.6.18",
+    "@types/angular-mocks": "^1.5.9",
+    "@types/angular-resource": "^1.5.8",
     "@types/jasmine": "^2.5.51",
+    "angular": ">=1.5.0",
     "angular-mocks": ">=1.5.0",
+    "angular-resource": ">=1.5.0",
     "browserify": "^14.4.0",
     "jasmine": "^2.6.0",
     "karma": "^1.7.0",
@@ -59,10 +64,7 @@
     "typescript": "^2.3.4",
     "watchify": "^3.9.0"
   },
-  "dependencies": {
-    "@types/angular": "^1.6.18",
-    "@types/angular-mocks": "^1.5.9",
-    "@types/angular-resource": "^1.5.8",
+  "peerDependencies": {
     "angular": ">=1.5.0",
     "angular-resource": ">=1.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -45,9 +45,7 @@
   },
   "homepage": "https://github.com/bcherny/ngimport#readme",
   "devDependencies": {
-    "@types/angular": "^1.6.18",
     "@types/angular-mocks": "^1.5.9",
-    "@types/angular-resource": "^1.5.8",
     "@types/jasmine": "^2.5.51",
     "angular": ">=1.5.0",
     "angular-mocks": ">=1.5.0",
@@ -63,6 +61,10 @@
     "tslint": "^5.4.2",
     "typescript": "^2.3.4",
     "watchify": "^3.9.0"
+  },
+  "dependencies":{
+    "@types/angular": "^1.6.18",
+    "@types/angular-resource": "^1.5.8"
   },
   "peerDependencies": {
     "angular": ">=1.5.0",


### PR DESCRIPTION
This seems to be the same issue that was in angular2react today (https://github.com/coatue-oss/angular2react/issues/17).

Angular and angular resource should be peer dependencies. By specifying them as regular dependencies, it can cause multiple copies to appear on the same page.